### PR TITLE
feat: extend cast condition for lists with different item names

### DIFF
--- a/crates/deltalake-core/src/data_catalog/unity/models.rs
+++ b/crates/deltalake-core/src/data_catalog/unity/models.rs
@@ -66,6 +66,7 @@ pub enum ListTableSummariesResponse {
     /// Successful response
     Success {
         /// Basic table infos
+        #[serde(default)]
         tables: Vec<TableSummary>,
         /// Continuation token
         next_page_token: Option<String>,
@@ -441,6 +442,16 @@ pub(crate) mod tests {
       }
     "#;
 
+    pub(crate) const LIST_TABLES: &str = r#"
+        {
+	        "tables": [{
+                "full_name": "catalog.schema.table_name",
+                "table_type": "MANAGED"
+            }]
+		}
+		"#;
+    pub(crate) const LIST_TABLES_EMPTY: &str = "{}";
+
     #[test]
     fn test_responses() {
         let list_schemas: Result<ListSchemasResponse, _> =
@@ -456,6 +467,21 @@ pub(crate) mod tests {
         assert!(matches!(
             get_table.unwrap(),
             GetTableResponse::Success { .. }
+        ));
+
+        let list_tables: Result<ListTableSummariesResponse, _> = serde_json::from_str(LIST_TABLES);
+        assert!(list_tables.is_ok());
+        assert!(matches!(
+            list_tables.unwrap(),
+            ListTableSummariesResponse::Success { .. }
+        ));
+
+        let list_tables: Result<ListTableSummariesResponse, _> =
+            serde_json::from_str(LIST_TABLES_EMPTY);
+        assert!(list_tables.is_ok());
+        assert!(matches!(
+            list_tables.unwrap(),
+            ListTableSummariesResponse::Success { .. }
         ));
 
         let get_schema: Result<GetSchemaResponse, _> = serde_json::from_str(GET_SCHEMA_RESPONSE);

--- a/crates/deltalake-core/src/delta_datafusion/expr.rs
+++ b/crates/deltalake-core/src/delta_datafusion/expr.rs
@@ -42,6 +42,8 @@ use sqlparser::tokenizer::Tokenizer;
 
 use crate::{DeltaResult, DeltaTableError};
 
+use super::DeltaParserOptions;
+
 pub(crate) struct DeltaContextProvider<'a> {
     state: &'a SessionState,
 }
@@ -97,7 +99,8 @@ pub(crate) fn parse_predicate_expression(
         })?;
 
     let context_provider = DeltaContextProvider { state: df_state };
-    let sql_to_rel = SqlToRel::new(&context_provider);
+    let sql_to_rel =
+        SqlToRel::new_with_options(&context_provider, DeltaParserOptions::default().into());
 
     Ok(sql_to_rel.sql_to_expr(sql, schema, &mut Default::default())?)
 }

--- a/crates/deltalake-core/src/delta_datafusion/mod.rs
+++ b/crates/deltalake-core/src/delta_datafusion/mod.rs
@@ -32,7 +32,9 @@ use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, SchemaR
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use arrow_array::types::UInt16Type;
-use arrow_array::{DictionaryArray, StringArray};
+use arrow_array::{Array, DictionaryArray, StringArray};
+use arrow_cast::display::array_value_to_string;
+
 use arrow_schema::Field;
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, TimeZone, Utc};
@@ -66,17 +68,20 @@ use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use datafusion_sql::planner::ParserOptions;
+
+use itertools::Itertools;
 use log::error;
 use object_store::ObjectMeta;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{Add, DataType as DeltaDataType, Invariant, PrimitiveType};
+use crate::kernel::{Add, DataCheck, DataType as DeltaDataType, Invariant, PrimitiveType};
 use crate::logstore::LogStoreRef;
 use crate::protocol::{ColumnCountStat, ColumnValueStat};
 use crate::table::builder::ensure_table_uri;
 use crate::table::state::DeltaTableState;
+use crate::table::Constraint;
 use crate::{open_table, open_table_with_storage_options, DeltaTable};
 
 const PATH_COLUMN: &str = "__delta_rs_path";
@@ -1017,15 +1022,43 @@ pub(crate) fn logical_expr_to_physical_expr(
 /// Responsible for checking batches of data conform to table's invariants.
 #[derive(Clone)]
 pub struct DeltaDataChecker {
+    constraints: Vec<Constraint>,
     invariants: Vec<Invariant>,
     ctx: SessionContext,
 }
 
 impl DeltaDataChecker {
-    /// Create a new DeltaDataChecker
-    pub fn new(invariants: Vec<Invariant>) -> Self {
+    /// Create a new DeltaDataChecker with a specified set of invariants
+    pub fn new_with_invariants(invariants: Vec<Invariant>) -> Self {
         Self {
             invariants,
+            constraints: vec![],
+            ctx: SessionContext::new(),
+        }
+    }
+
+    /// Create a new DeltaDataChecker with a specified set of constraints
+    pub fn new_with_constraints(constraints: Vec<Constraint>) -> Self {
+        Self {
+            constraints,
+            invariants: vec![],
+            ctx: SessionContext::new(),
+        }
+    }
+
+    /// Create a new DeltaDataChecker
+    pub fn new(snapshot: &DeltaTableState) -> Self {
+        let metadata = snapshot.metadata();
+
+        let invariants = metadata
+            .and_then(|meta| meta.schema.get_invariants().ok())
+            .unwrap_or_default();
+        let constraints = metadata
+            .map(|meta| meta.get_constraints())
+            .unwrap_or_default();
+        Self {
+            invariants,
+            constraints,
             ctx: SessionContext::new(),
         }
     }
@@ -1035,45 +1068,54 @@ impl DeltaDataChecker {
     /// If it does not, it will return [DeltaTableError::InvalidData] with a list
     /// of values that violated each invariant.
     pub async fn check_batch(&self, record_batch: &RecordBatch) -> Result<(), DeltaTableError> {
-        self.enforce_invariants(record_batch).await
-        // TODO: for support for Protocol V3, check constraints
+        self.enforce_checks(record_batch, &self.invariants).await?;
+        self.enforce_checks(record_batch, &self.constraints).await
     }
 
-    async fn enforce_invariants(&self, record_batch: &RecordBatch) -> Result<(), DeltaTableError> {
-        // Invariants are deprecated, so let's not pay the overhead for any of this
-        // if we can avoid it.
-        if self.invariants.is_empty() {
+    async fn enforce_checks<C: DataCheck>(
+        &self,
+        record_batch: &RecordBatch,
+        checks: &[C],
+    ) -> Result<(), DeltaTableError> {
+        if checks.is_empty() {
             return Ok(());
         }
-
         let table = MemTable::try_new(record_batch.schema(), vec![vec![record_batch.clone()]])?;
         self.ctx.register_table("data", Arc::new(table))?;
 
         let mut violations: Vec<String> = Vec::new();
 
-        for invariant in self.invariants.iter() {
-            if invariant.field_name.contains('.') {
+        for check in checks {
+            if check.get_name().contains('.') {
                 return Err(DeltaTableError::Generic(
-                    "Support for column invariants on nested columns is not supported.".to_string(),
+                    "Support for nested columns is not supported.".to_string(),
                 ));
             }
 
             let sql = format!(
-                "SELECT {} FROM data WHERE not ({}) LIMIT 1",
-                invariant.field_name, invariant.invariant_sql
+                "SELECT {} FROM data WHERE NOT ({}) LIMIT 1",
+                check.get_name(),
+                check.get_expression()
             );
 
             let dfs: Vec<RecordBatch> = self.ctx.sql(&sql).await?.collect().await?;
             if !dfs.is_empty() && dfs[0].num_rows() > 0 {
-                let value = format!("{:?}", dfs[0].column(0));
+                let value: String = dfs[0]
+                    .columns()
+                    .iter()
+                    .map(|c| array_value_to_string(c, 0).unwrap_or(String::from("null")))
+                    .join(", ");
+
                 let msg = format!(
-                    "Invariant ({}) violated by value {}",
-                    invariant.invariant_sql, value
+                    "Check or Invariant ({}) violated by value in row: [{}]",
+                    check.get_expression(),
+                    value
                 );
                 violations.push(msg);
             }
         }
 
+        self.ctx.deregister_table("data")?;
         if !violations.is_empty() {
             Err(DeltaTableError::InvalidData { violations })
         } else {
@@ -1747,7 +1789,7 @@ mod tests {
         .unwrap();
         // Empty invariants is okay
         let invariants: Vec<Invariant> = vec![];
-        assert!(DeltaDataChecker::new(invariants)
+        assert!(DeltaDataChecker::new_with_invariants(invariants)
             .check_batch(&batch)
             .await
             .is_ok());
@@ -1757,7 +1799,7 @@ mod tests {
             Invariant::new("a", "a is not null"),
             Invariant::new("b", "b < 1000"),
         ];
-        assert!(DeltaDataChecker::new(invariants)
+        assert!(DeltaDataChecker::new_with_invariants(invariants)
             .check_batch(&batch)
             .await
             .is_ok());
@@ -1767,7 +1809,9 @@ mod tests {
             Invariant::new("a", "a is null"),
             Invariant::new("b", "b < 100"),
         ];
-        let result = DeltaDataChecker::new(invariants).check_batch(&batch).await;
+        let result = DeltaDataChecker::new_with_invariants(invariants)
+            .check_batch(&batch)
+            .await;
         assert!(result.is_err());
         assert!(matches!(result, Err(DeltaTableError::InvalidData { .. })));
         if let Err(DeltaTableError::InvalidData { violations }) = result {
@@ -1776,7 +1820,9 @@ mod tests {
 
         // Irrelevant invariants return a different error
         let invariants = vec![Invariant::new("c", "c > 2000")];
-        let result = DeltaDataChecker::new(invariants).check_batch(&batch).await;
+        let result = DeltaDataChecker::new_with_invariants(invariants)
+            .check_batch(&batch)
+            .await;
         assert!(result.is_err());
 
         // Nested invariants are unsupported
@@ -1790,7 +1836,9 @@ mod tests {
         let batch = RecordBatch::try_new(schema, vec![inner]).unwrap();
 
         let invariants = vec![Invariant::new("x.b", "x.b < 1000")];
-        let result = DeltaDataChecker::new(invariants).check_batch(&batch).await;
+        let result = DeltaDataChecker::new_with_invariants(invariants)
+            .check_batch(&batch)
+            .await;
         assert!(result.is_err());
         assert!(matches!(result, Err(DeltaTableError::Generic { .. })));
     }

--- a/crates/deltalake-core/src/kernel/actions/types.rs
+++ b/crates/deltalake-core/src/kernel/actions/types.rs
@@ -130,9 +130,11 @@ pub struct Protocol {
     pub min_writer_version: i32,
     /// A collection of features that a client must implement in order to correctly
     /// read this table (exist only when minReaderVersion is set to 3)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reader_features: Option<HashSet<ReaderFeatures>>,
     /// A collection of features that a client must implement in order to correctly
     /// write this table (exist only when minWriterVersion is set to 7)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub writer_features: Option<HashSet<WriterFeatures>>,
 }
 

--- a/crates/deltalake-core/src/kernel/mod.rs
+++ b/crates/deltalake-core/src/kernel/mod.rs
@@ -13,3 +13,11 @@ pub use actions::*;
 pub use error::*;
 pub use expressions::*;
 pub use schema::*;
+
+/// A trait for all kernel types that are used as part of data checking
+pub trait DataCheck {
+    /// The name of the specific check
+    fn get_name(&self) -> &str;
+    /// The SQL expression to use for the check
+    fn get_expression(&self) -> &str;
+}

--- a/crates/deltalake-core/src/kernel/schema.rs
+++ b/crates/deltalake-core/src/kernel/schema.rs
@@ -6,6 +6,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::{collections::HashMap, fmt::Display};
 
+use crate::kernel::DataCheck;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -94,6 +95,16 @@ impl Invariant {
             field_name: field_name.to_string(),
             invariant_sql: invariant_sql.to_string(),
         }
+    }
+}
+
+impl DataCheck for Invariant {
+    fn get_name(&self) -> &str {
+        &self.field_name
+    }
+
+    fn get_expression(&self) -> &str {
+        &self.invariant_sql
     }
 }
 

--- a/crates/deltalake-core/src/operations/cast.rs
+++ b/crates/deltalake-core/src/operations/cast.rs
@@ -17,6 +17,7 @@ fn cast_record_batch_columns(
         .iter()
         .map(|f| {
             let col = batch.column_by_name(f.name()).unwrap();
+
             if let (DataType::Struct(_), DataType::Struct(child_fields)) =
                 (col.data_type(), f.data_type())
             {
@@ -28,13 +29,25 @@ fn cast_record_batch_columns(
                     child_columns.clone(),
                     None,
                 )) as ArrayRef)
-            } else if !col.data_type().equals_datatype(f.data_type()) {
+            } else if is_cast_required(col.data_type(), f.data_type()) {
                 cast_with_options(col, f.data_type(), cast_options)
             } else {
                 Ok(col.clone())
             }
         })
         .collect::<Result<Vec<_>, _>>()
+}
+
+fn is_cast_required(a: &DataType, b: &DataType) -> bool {
+    match (a, b) {
+        (DataType::List(a_item), DataType::List(b_item)) => {
+            // If list item name is not the default('item') the list must be casted
+            !a.equals_datatype(b) || a_item.name() != b_item.name()
+        }
+        (_, _) => {
+             !a.equals_datatype(b)
+        }
+    }
 }
 
 /// Cast recordbatch to a new target_schema, by casting each column array
@@ -50,4 +63,74 @@ pub fn cast_record_batch(
 
     let columns = cast_record_batch_columns(batch, target_schema.fields(), &cast_options)?;
     Ok(RecordBatch::try_new(target_schema, columns)?)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use arrow::array::ArrayData;
+    use arrow_array::{Array, ArrayRef, ListArray, RecordBatch};
+    use arrow_buffer::Buffer;
+    use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef};
+    use crate::operations::cast::{cast_record_batch, is_cast_required};
+
+    #[test]
+    fn test_cast_record_batch_with_list_non_default_item(){
+        let array = Arc::new(make_list_array()) as ArrayRef;
+        let source_schema = Schema::new(vec![
+            Field::new("list_column", array.data_type().clone(), false)
+        ]);
+        let record_batch = RecordBatch::try_new(Arc::new(source_schema), vec![array]).unwrap();
+
+        let fields = Fields::from(vec![Field::new_list("list_column", Field::new("item", DataType::Int8, false), false)]);
+        let target_schema = Arc::new(Schema::new(fields)) as SchemaRef;
+
+        let result = cast_record_batch(&record_batch, target_schema, false);
+
+        let schema =  result.unwrap().schema();
+        let field = schema.column_with_name("list_column").unwrap().1;
+        if let DataType::List(list_item) = field.data_type() {
+            assert_eq!(list_item.name(), "item");
+        } else {
+            panic!("Not a list");
+        }
+    }
+
+    fn make_list_array() -> ListArray {
+        let value_data = ArrayData::builder(DataType::Int32)
+            .len(8)
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
+            .build()
+            .unwrap();
+
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 8]);
+
+        let list_data_type =
+            DataType::List(Arc::new(Field::new("element", DataType::Int32, true)));
+        let list_data = ArrayData::builder(list_data_type)
+            .len(3)
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
+            .build()
+            .unwrap();
+        ListArray::from(list_data)
+    }
+
+    #[test]
+    fn test_is_cast_required_with_list() {
+        let field1 = DataType::List(FieldRef::from(Field::new("item", DataType::Int32, false)));
+        let field2 = DataType::List(FieldRef::from(Field::new("item", DataType::Int32, false)));
+
+        assert!(!is_cast_required(&field1, &field2));
+    }
+
+    #[test]
+    fn test_is_cast_required_with_list_non_default_item() {
+        let field1 = DataType::List(FieldRef::from(Field::new("element", DataType::Int32, false)));
+        let field2 = DataType::List(FieldRef::from(Field::new("item", DataType::Int32, false)));
+
+        assert!(is_cast_required(&field1, &field2));
+    }
+
 }

--- a/crates/deltalake-core/src/operations/constraints.rs
+++ b/crates/deltalake-core/src/operations/constraints.rs
@@ -1,0 +1,315 @@
+//! Add a check constraint to a table
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+use datafusion::execution::context::SessionState;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionContext;
+use futures::future::BoxFuture;
+use futures::StreamExt;
+use serde_json::json;
+
+use crate::delta_datafusion::{register_store, DeltaDataChecker, DeltaScanBuilder};
+use crate::kernel::{Action, CommitInfo, IsolationLevel, Metadata, Protocol};
+use crate::logstore::LogStoreRef;
+use crate::operations::datafusion_utils::Expression;
+use crate::operations::transaction::commit;
+use crate::protocol::DeltaOperation;
+use crate::table::state::DeltaTableState;
+use crate::table::Constraint;
+use crate::DeltaTable;
+use crate::{DeltaResult, DeltaTableError};
+
+/// Build a constraint to add to a table
+pub struct ConstraintBuilder {
+    snapshot: DeltaTableState,
+    name: Option<String>,
+    expr: Option<Expression>,
+    log_store: LogStoreRef,
+    state: Option<SessionState>,
+}
+
+impl ConstraintBuilder {
+    /// Create a new builder
+    pub fn new(log_store: LogStoreRef, snapshot: DeltaTableState) -> Self {
+        Self {
+            name: None,
+            expr: None,
+            snapshot,
+            log_store,
+            state: None,
+        }
+    }
+
+    /// Specify the constraint to be added
+    pub fn with_constraint<S: Into<String>, E: Into<Expression>>(
+        mut self,
+        column: S,
+        expression: E,
+    ) -> Self {
+        self.name = Some(column.into());
+        self.expr = Some(expression.into());
+        self
+    }
+
+    /// Specify the datafusion session context
+    pub fn with_session_state(mut self, state: SessionState) -> Self {
+        self.state = Some(state);
+        self
+    }
+}
+
+impl std::future::IntoFuture for ConstraintBuilder {
+    type Output = DeltaResult<DeltaTable>;
+
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let mut this = self;
+
+        Box::pin(async move {
+            let name = match this.name {
+                Some(v) => v,
+                None => return Err(DeltaTableError::Generic("No name provided".to_string())),
+            };
+            let expr = match this.expr {
+                Some(Expression::String(s)) => s,
+                Some(Expression::DataFusion(e)) => e.to_string(),
+                None => {
+                    return Err(DeltaTableError::Generic(
+                        "No expression provided".to_string(),
+                    ))
+                }
+            };
+
+            let mut metadata = this
+                .snapshot
+                .metadata()
+                .ok_or(DeltaTableError::NoMetadata)?
+                .clone();
+            let configuration_key = format!("delta.constraints.{}", name);
+
+            if metadata.configuration.contains_key(&configuration_key) {
+                return Err(DeltaTableError::Generic(format!(
+                    "Constraint with name: {} already exists, expr: {}",
+                    name, expr
+                )));
+            }
+
+            let state = this.state.unwrap_or_else(|| {
+                let session = SessionContext::new();
+                register_store(this.log_store.clone(), session.runtime_env());
+                session.state()
+            });
+
+            // Checker built here with the one time constraint to check.
+            let checker = DeltaDataChecker::new_with_constraints(vec![Constraint::new("*", &expr)]);
+            let scan = DeltaScanBuilder::new(&this.snapshot, this.log_store.clone(), &state)
+                .build()
+                .await?;
+
+            let plan: Arc<dyn ExecutionPlan> = Arc::new(scan);
+            let mut tasks = vec![];
+            for p in 0..plan.output_partitioning().partition_count() {
+                let inner_plan = plan.clone();
+                let inner_checker = checker.clone();
+                let task_ctx = Arc::new(TaskContext::from(&state));
+                let mut record_stream: SendableRecordBatchStream =
+                    inner_plan.execute(p, task_ctx)?;
+                let handle: tokio::task::JoinHandle<DeltaResult<()>> =
+                    tokio::task::spawn(async move {
+                        while let Some(maybe_batch) = record_stream.next().await {
+                            let batch = maybe_batch?;
+                            inner_checker.check_batch(&batch).await?;
+                        }
+                        Ok(())
+                    });
+                tasks.push(handle);
+            }
+            futures::future::join_all(tasks)
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| DeltaTableError::Generic(err.to_string()))?
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()?;
+
+            // We have validated the table passes it's constraints, now to add the constraint to
+            // the table.
+
+            metadata
+                .configuration
+                .insert(format!("delta.constraints.{}", name), Some(expr.clone()));
+
+            let old_protocol = this.snapshot.protocol();
+            let protocol = Protocol {
+                min_reader_version: if old_protocol.min_reader_version > 1 {
+                    old_protocol.min_reader_version
+                } else {
+                    1
+                },
+                min_writer_version: if old_protocol.min_writer_version > 3 {
+                    old_protocol.min_writer_version
+                } else {
+                    3
+                },
+                reader_features: old_protocol.reader_features.clone(),
+                writer_features: old_protocol.writer_features.clone(),
+            };
+
+            let operational_parameters = HashMap::from_iter([
+                ("name".to_string(), json!(&name)),
+                ("expr".to_string(), json!(&expr)),
+            ]);
+
+            let operations = DeltaOperation::AddConstraint {
+                name: name.clone(),
+                expr: expr.clone(),
+            };
+
+            let commit_info = CommitInfo {
+                timestamp: Some(Utc::now().timestamp_millis()),
+                operation: Some(operations.name().to_string()),
+                operation_parameters: Some(operational_parameters),
+                read_version: Some(this.snapshot.version()),
+                isolation_level: Some(IsolationLevel::Serializable),
+                is_blind_append: Some(false),
+                ..Default::default()
+            };
+
+            let actions = vec![
+                Action::CommitInfo(commit_info),
+                Action::Metadata(Metadata::try_from(metadata)?),
+                Action::Protocol(protocol),
+            ];
+
+            let version = commit(
+                this.log_store.as_ref(),
+                &actions,
+                operations,
+                &this.snapshot,
+                None,
+            )
+            .await?;
+
+            this.snapshot
+                .merge(DeltaTableState::from_actions(actions, version)?, true, true);
+            Ok(DeltaTable::new_with_state(this.log_store, this.snapshot))
+        })
+    }
+}
+
+#[cfg(feature = "datafusion")]
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Array, Int32Array, RecordBatch, StringArray};
+
+    use crate::writer::test_utils::{create_bare_table, get_arrow_schema, get_record_batch};
+    use crate::{DeltaOps, DeltaResult};
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
+    async fn add_constraint_with_invalid_data() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await?;
+        let table = DeltaOps(write);
+
+        let constraint = table
+            .add_constraint()
+            .with_constraint("id", "value > 5")
+            .await;
+        dbg!(&constraint);
+        assert!(constraint.is_err());
+        Ok(())
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
+    async fn add_valid_constraint() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await?;
+        let table = DeltaOps(write);
+
+        let constraint = table
+            .add_constraint()
+            .with_constraint("id", "value < 1000")
+            .await;
+        dbg!(&constraint);
+        assert!(constraint.is_ok());
+        let version = constraint?.version();
+        assert_eq!(version, 1);
+        Ok(())
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
+    async fn add_conflicting_named_constraint() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await?;
+        let table = DeltaOps(write);
+
+        let new_table = table
+            .add_constraint()
+            .with_constraint("id", "value < 60")
+            .await?;
+
+        let new_table = DeltaOps(new_table);
+        let second_constraint = new_table
+            .add_constraint()
+            .with_constraint("id", "value < 10")
+            .await;
+        dbg!(&second_constraint);
+        assert!(second_constraint.is_err());
+        Ok(())
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
+    async fn write_data_that_violates_constraint() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await?;
+
+        let table = DeltaOps(write)
+            .add_constraint()
+            .with_constraint("id", "value > 0")
+            .await?;
+        let table = DeltaOps(table);
+        let invalid_values: Vec<Arc<dyn Array>> = vec![
+            Arc::new(StringArray::from(vec!["A"])),
+            Arc::new(Int32Array::from(vec![-10])),
+            Arc::new(StringArray::from(vec!["2021-02-02"])),
+        ];
+        let batch = RecordBatch::try_new(get_arrow_schema(&None), invalid_values)?;
+        let err = table.write(vec![batch]).await;
+        dbg!(&err);
+        assert!(err.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn write_data_that_does_not_violate_constraint() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await?;
+        let table = DeltaOps(write);
+
+        let err = table.write(vec![batch]).await;
+
+        assert!(err.is_ok());
+        Ok(())
+    }
+}

--- a/crates/deltalake-core/src/operations/delete.rs
+++ b/crates/deltalake-core/src/operations/delete.rs
@@ -37,7 +37,7 @@ use serde_json::Value;
 use super::datafusion_utils::Expression;
 use super::transaction::PROTOCOL;
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
-use crate::delta_datafusion::{find_files, register_store, DeltaScanBuilder};
+use crate::delta_datafusion::{find_files, register_store, DeltaScanBuilder, DeltaSessionContext};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::{Action, Add, Remove};
 use crate::operations::transaction::commit;
@@ -280,7 +280,7 @@ impl std::future::IntoFuture for DeleteBuilder {
             PROTOCOL.can_write_to(&this.snapshot)?;
 
             let state = this.state.unwrap_or_else(|| {
-                let session = SessionContext::new();
+                let session: SessionContext = DeltaSessionContext::default().into();
 
                 // If a user provides their own their DF state then they must register the store themselves
                 register_store(this.log_store.clone(), session.runtime_env());

--- a/crates/deltalake-core/src/operations/merge.rs
+++ b/crates/deltalake-core/src/operations/merge.rs
@@ -65,7 +65,9 @@ use super::transaction::{commit, PROTOCOL};
 use crate::delta_datafusion::expr::{fmt_expr_to_sql, parse_predicate_expression};
 use crate::delta_datafusion::logical::MetricObserver;
 use crate::delta_datafusion::physical::{find_metric_node, MetricObserverExec};
-use crate::delta_datafusion::{register_store, DeltaScanConfig, DeltaTableProvider};
+use crate::delta_datafusion::{
+    register_store, DeltaColumn, DeltaScanConfig, DeltaSessionConfig, DeltaTableProvider,
+};
 use crate::kernel::{Action, Remove};
 use crate::logstore::LogStoreRef;
 use crate::operations::write::write_execution_plan;
@@ -391,12 +393,12 @@ impl UpdateBuilder {
     /// How a column from the target table should be updated.
     /// In the match case the expression may contain both source and target columns.
     /// In the source not match case the expression may only contain target columns
-    pub fn update<C: Into<Column>, E: Into<Expression>>(
+    pub fn update<C: Into<DeltaColumn>, E: Into<Expression>>(
         mut self,
         column: C,
         expression: E,
     ) -> Self {
-        self.updates.insert(column.into(), expression.into());
+        self.updates.insert(column.into().into(), expression.into());
         self
     }
 }
@@ -419,8 +421,12 @@ impl InsertBuilder {
 
     /// Which values to insert into the target tables. If a target column is not
     /// specified then null is inserted.
-    pub fn set<C: Into<Column>, E: Into<Expression>>(mut self, column: C, expression: E) -> Self {
-        self.set.insert(column.into(), expression.into());
+    pub fn set<C: Into<DeltaColumn>, E: Into<Expression>>(
+        mut self,
+        column: C,
+        expression: E,
+    ) -> Self {
+        self.set.insert(column.into().into(), expression.into());
         self
     }
 }
@@ -888,7 +894,10 @@ async fn execute(
         .end()?;
 
         let name = "__delta_rs_c_".to_owned() + delta_field.name();
-        write_projection.push(col(name.clone()).alias(delta_field.name()));
+        write_projection.push(
+            Expr::Column(Column::from_qualified_name_ignore_case(name.clone()))
+                .alias(delta_field.name()),
+        );
         new_columns = new_columns.with_column(&name, case)?;
     }
 
@@ -1112,7 +1121,8 @@ impl std::future::IntoFuture for MergeBuilder {
 
             let state = this.state.unwrap_or_else(|| {
                 //TODO: Datafusion's Hashjoin has some memory issues. Running with all cores results in a OoM. Can be removed when upstream improvemetns are made.
-                let config = SessionConfig::new().with_target_partitions(1);
+                let config: SessionConfig = DeltaSessionConfig::default().into();
+                let config = config.with_target_partitions(1);
                 let session = SessionContext::new_with_config(config);
 
                 // If a user provides their own their DF state then they must register the store themselves
@@ -1149,6 +1159,9 @@ impl std::future::IntoFuture for MergeBuilder {
 
 #[cfg(test)]
 mod tests {
+    use crate::kernel::DataType;
+    use crate::kernel::PrimitiveType;
+    use crate::kernel::StructField;
     use crate::operations::DeltaOps;
     use crate::protocol::*;
     use crate::writer::test_utils::datafusion::get_data;
@@ -1159,6 +1172,8 @@ mod tests {
     use crate::DeltaTable;
     use arrow::datatypes::Schema as ArrowSchema;
     use arrow::record_batch::RecordBatch;
+    use arrow_schema::DataType as ArrowDataType;
+    use arrow_schema::Field;
     use datafusion::assert_batches_sorted_eq;
     use datafusion::prelude::DataFrame;
     use datafusion::prelude::SessionContext;
@@ -1914,6 +1929,87 @@ mod tests {
             "| B  | 10    | 2021-02-02 |",
             "| C  | 20    | 2023-07-04 |",
             "| X  | 30    | 2023-07-04 |",
+            "+----+-------+------------+",
+        ];
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn test_merge_case_sensitive() {
+        let schema = vec![
+            StructField::new(
+                "Id".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+            StructField::new(
+                "vAlue".to_string(),
+                DataType::Primitive(PrimitiveType::Integer),
+                true,
+            ),
+            StructField::new(
+                "mOdifieD".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+        ];
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("Id", ArrowDataType::Utf8, true),
+            Field::new("vAlue", ArrowDataType::Int32, true),
+            Field::new("mOdifieD", ArrowDataType::Utf8, true),
+        ]));
+
+        let table = DeltaOps::new_in_memory()
+            .create()
+            .with_columns(schema)
+            .await
+            .unwrap();
+
+        let ctx = SessionContext::new();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&arrow_schema.clone()),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B", "C", "X"])),
+                Arc::new(arrow::array::Int32Array::from(vec![10, 20, 30])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2021-02-02",
+                    "2023-07-04",
+                    "2023-07-04",
+                ])),
+            ],
+        )
+        .unwrap();
+        let source = ctx.read_batch(batch).unwrap();
+
+        let table = write_data(table, &arrow_schema).await;
+        assert_eq!(table.version(), 1);
+        assert_eq!(table.get_file_uris().count(), 1);
+
+        let (table, _metrics) = DeltaOps(table)
+            .merge(source, "target.Id = source.Id")
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_not_matched_insert(|insert| {
+                insert
+                    .set("Id", "source.Id")
+                    .set("vAlue", "source.vAlue + 1")
+                    .set("mOdifieD", "source.mOdifieD")
+            })
+            .unwrap()
+            .await
+            .unwrap();
+
+        let expected = vec![
+            "+----+-------+------------+",
+            "| Id | vAlue | mOdifieD   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| B  | 10    | 2021-02-01 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "| X  | 31    | 2023-07-04 |",
             "+----+-------+------------+",
         ];
         let actual = get_data(&table).await;

--- a/crates/deltalake-core/src/operations/mod.rs
+++ b/crates/deltalake-core/src/operations/mod.rs
@@ -29,8 +29,8 @@ pub mod vacuum;
 
 #[cfg(feature = "datafusion")]
 use self::{
-    datafusion_utils::Expression, delete::DeleteBuilder, load::LoadBuilder, merge::MergeBuilder,
-    update::UpdateBuilder, write::WriteBuilder,
+    constraints::ConstraintBuilder, datafusion_utils::Expression, delete::DeleteBuilder,
+    load::LoadBuilder, merge::MergeBuilder, update::UpdateBuilder, write::WriteBuilder,
 };
 #[cfg(feature = "datafusion")]
 pub use ::datafusion::physical_plan::common::collect as collect_sendable_stream;
@@ -40,6 +40,8 @@ use arrow::record_batch::RecordBatch;
 use optimize::OptimizeBuilder;
 use restore::RestoreBuilder;
 
+#[cfg(feature = "datafusion")]
+pub mod constraints;
 #[cfg(feature = "datafusion")]
 pub mod delete;
 #[cfg(feature = "datafusion")]
@@ -188,6 +190,13 @@ impl DeltaOps {
         predicate: E,
     ) -> MergeBuilder {
         MergeBuilder::new(self.0.log_store, self.0.state, predicate.into(), source)
+    }
+
+    /// Add a check constraint to a table
+    #[cfg(feature = "datafusion")]
+    #[must_use]
+    pub fn add_constraint(self) -> ConstraintBuilder {
+        ConstraintBuilder::new(self.0.log_store, self.0.state)
     }
 }
 

--- a/crates/deltalake-core/src/operations/transaction/protocol.rs
+++ b/crates/deltalake-core/src/operations/transaction/protocol.rs
@@ -170,7 +170,7 @@ pub static INSTANCE: Lazy<ProtocolChecker> = Lazy::new(|| {
     let mut writer_features = HashSet::new();
     writer_features.insert(WriterFeatures::AppendOnly);
     writer_features.insert(WriterFeatures::Invariants);
-    // writer_features.insert(WriterFeatures::CheckConstraints);
+    writer_features.insert(WriterFeatures::CheckConstraints);
     // writer_features.insert(WriterFeatures::ChangeDataFeed);
     // writer_features.insert(WriterFeatures::GeneratedColumns);
     // writer_features.insert(WriterFeatures::ColumnMapping);

--- a/crates/deltalake-core/src/operations/update.rs
+++ b/crates/deltalake-core/src/operations/update.rs
@@ -46,7 +46,9 @@ use serde_json::Value;
 use super::datafusion_utils::Expression;
 use super::transaction::{commit, PROTOCOL};
 use super::write::write_execution_plan;
-use crate::delta_datafusion::{expr::fmt_expr_to_sql, physical::MetricObserverExec};
+use crate::delta_datafusion::{
+    expr::fmt_expr_to_sql, physical::MetricObserverExec, DeltaColumn, DeltaSessionContext,
+};
 use crate::delta_datafusion::{find_files, register_store, DeltaScanBuilder};
 use crate::kernel::{Action, Remove};
 use crate::logstore::LogStoreRef;
@@ -115,12 +117,12 @@ impl UpdateBuilder {
     }
 
     /// Perform an additional update expression during the operaton
-    pub fn with_update<S: Into<Column>, E: Into<Expression>>(
+    pub fn with_update<S: Into<DeltaColumn>, E: Into<Expression>>(
         mut self,
         column: S,
         expression: E,
     ) -> Self {
-        self.updates.insert(column.into(), expression.into());
+        self.updates.insert(column.into().into(), expression.into());
         self
     }
 
@@ -431,7 +433,7 @@ impl std::future::IntoFuture for UpdateBuilder {
             PROTOCOL.can_write_to(&this.snapshot)?;
 
             let state = this.state.unwrap_or_else(|| {
-                let session = SessionContext::new();
+                let session: SessionContext = DeltaSessionContext::default().into();
 
                 // If a user provides their own their DF state then they must register the store themselves
                 register_store(this.log_store.clone(), session.runtime_env());
@@ -462,6 +464,10 @@ impl std::future::IntoFuture for UpdateBuilder {
 
 #[cfg(test)]
 mod tests {
+    use crate::kernel::DataType as DeltaDataType;
+    use crate::kernel::PrimitiveType;
+    use crate::kernel::StructField;
+    use crate::kernel::StructType;
     use crate::operations::DeltaOps;
     use crate::writer::test_utils::datafusion::get_data;
     use crate::writer::test_utils::datafusion::write_batch;
@@ -470,9 +476,11 @@ mod tests {
     };
     use crate::DeltaConfigKey;
     use crate::DeltaTable;
+    use arrow::datatypes::Schema as ArrowSchema;
     use arrow::datatypes::{Field, Schema};
     use arrow::record_batch::RecordBatch;
     use arrow_array::Int32Array;
+    use arrow_schema::DataType;
     use datafusion::assert_batches_sorted_eq;
     use datafusion::prelude::*;
     use serde_json::json;
@@ -722,6 +730,77 @@ mod tests {
             "| A  | 1     | 2021-02-02 |",
             "| A  | 10    | 2021-02-03 |",
             "| B  | 10    | 2021-02-02 |",
+            "| C  | 100   | 2023-05-14 |",
+            "+----+-------+------------+",
+        ];
+
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn test_update_case_sensitive() {
+        let schema = StructType::new(vec![
+            StructField::new(
+                "Id".to_string(),
+                DeltaDataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+            StructField::new(
+                "ValUe".to_string(),
+                DeltaDataType::Primitive(PrimitiveType::Integer),
+                true,
+            ),
+            StructField::new(
+                "mOdified".to_string(),
+                DeltaDataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+        ]);
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("Id", DataType::Utf8, true),
+            Field::new("ValUe", DataType::Int32, true),
+            Field::new("mOdified", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&arrow_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["A", "B", "A", "A"])),
+                Arc::new(arrow::array::Int32Array::from(vec![1, 10, 10, 100])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2021-02-02",
+                    "2021-02-02",
+                    "2021-02-03",
+                    "2021-02-03",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let table = DeltaOps::new_in_memory()
+            .create()
+            .with_columns(schema.fields().clone())
+            .await
+            .unwrap();
+        let table = write_batch(table, batch).await;
+
+        let (table, _metrics) = DeltaOps(table)
+            .update()
+            .with_predicate("mOdified = '2021-02-03'")
+            .with_update("mOdified", "'2023-05-14'")
+            .with_update("Id", "'C'")
+            .await
+            .unwrap();
+
+        let expected = vec![
+            "+----+-------+------------+",
+            "| Id | ValUe | mOdified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-02 |",
+            "| B  | 10    | 2021-02-02 |",
+            "| C  | 10    | 2023-05-14 |",
             "| C  | 100   | 2023-05-14 |",
             "+----+-------+------------+",
         ];

--- a/crates/deltalake-core/src/operations/write.rs
+++ b/crates/deltalake-core/src/operations/write.rs
@@ -306,11 +306,6 @@ pub(crate) async fn write_execution_plan(
     safe_cast: bool,
     overwrite_schema: bool,
 ) -> DeltaResult<Vec<Add>> {
-    let invariants = snapshot
-        .metadata()
-        .and_then(|meta| meta.schema.get_invariants().ok())
-        .unwrap_or_default();
-
     // Use input schema to prevent wrapping partitions columns into a dictionary.
     let schema: ArrowSchemaRef = if overwrite_schema {
         plan.schema()
@@ -318,7 +313,7 @@ pub(crate) async fn write_execution_plan(
         snapshot.input_schema().unwrap_or(plan.schema())
     };
 
-    let checker = DeltaDataChecker::new(invariants);
+    let checker = DeltaDataChecker::new(snapshot);
 
     // Write data to disk
     let mut tasks = vec![];

--- a/crates/deltalake-core/src/protocol/mod.rs
+++ b/crates/deltalake-core/src/protocol/mod.rs
@@ -410,6 +410,13 @@ pub enum DeltaOperation {
         /// The update predicate
         predicate: Option<String>,
     },
+    /// Add constraints to a table
+    AddConstraint {
+        /// Constraints name
+        name: String,
+        /// Expression to check against
+        expr: String,
+    },
 
     /// Merge data with a source data with the following predicate
     #[serde(rename_all = "camelCase")]
@@ -497,6 +504,7 @@ impl DeltaOperation {
             DeltaOperation::Restore { .. } => "RESTORE",
             DeltaOperation::VacuumStart { .. } => "VACUUM START",
             DeltaOperation::VacuumEnd { .. } => "VACUUM END",
+            DeltaOperation::AddConstraint { .. } => "ADD CONSTRAINT",
         }
     }
 
@@ -532,7 +540,10 @@ impl DeltaOperation {
     /// Denotes if the operation changes the data contained in the table
     pub fn changes_data(&self) -> bool {
         match self {
-            Self::Optimize { .. } | Self::VacuumStart { .. } | Self::VacuumEnd { .. } => false,
+            Self::Optimize { .. }
+            | Self::VacuumStart { .. }
+            | Self::VacuumEnd { .. }
+            | Self::AddConstraint { .. } => false,
             Self::Create { .. }
             | Self::FileSystemCheck {}
             | Self::StreamingUpdate { .. }

--- a/crates/deltalake-core/src/table/mod.rs
+++ b/crates/deltalake-core/src/table/mod.rs
@@ -21,8 +21,8 @@ use self::builder::DeltaTableConfig;
 use self::state::DeltaTableState;
 use crate::errors::DeltaTableError;
 use crate::kernel::{
-    Action, Add, CommitInfo, DataType, Format, Metadata, Protocol, ReaderFeatures, Remove,
-    StructType, WriterFeatures,
+    Action, Add, CommitInfo, DataCheck, DataType, Format, Metadata, Protocol, ReaderFeatures,
+    Remove, StructType, WriterFeatures,
 };
 use crate::logstore::LogStoreRef;
 use crate::logstore::{self, LogStoreConfig};
@@ -136,6 +136,35 @@ impl PartialEq for CheckPoint {
 
 impl Eq for CheckPoint {}
 
+/// A constraint in a check constraint
+#[derive(Eq, PartialEq, Debug, Default, Clone)]
+pub struct Constraint {
+    /// The full path to the field.
+    pub name: String,
+    /// The SQL string that must always evaluate to true.
+    pub expr: String,
+}
+
+impl Constraint {
+    /// Create a new invariant
+    pub fn new(field_name: &str, invariant_sql: &str) -> Self {
+        Self {
+            name: field_name.to_string(),
+            expr: invariant_sql.to_string(),
+        }
+    }
+}
+
+impl DataCheck for Constraint {
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_expression(&self) -> &str {
+        &self.expr
+    }
+}
+
 /// Delta table metadata
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct DeltaTableMetaData {
@@ -185,6 +214,20 @@ impl DeltaTableMetaData {
     /// Return the configurations of the DeltaTableMetaData; could be empty
     pub fn get_configuration(&self) -> &HashMap<String, Option<String>> {
         &self.configuration
+    }
+
+    /// Return the check constraints on the current table
+    pub fn get_constraints(&self) -> Vec<Constraint> {
+        self.configuration
+            .iter()
+            .filter_map(|(field, value)| {
+                if field.starts_with("delta.constraints") {
+                    value.as_ref().map(|f| Constraint::new("*", f))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Return partition fields along with their data type from the current schema.
@@ -953,6 +996,27 @@ mod tests {
             let table = DeltaTableBuilder::from_uri(table_uri).build().unwrap();
             assert_eq!(table.table_uri(), "s3://tests/data/delta-0.8.0");
         }
+    }
+
+    #[test]
+    fn get_table_constraints() {
+        let state = DeltaTableMetaData::new(
+            None,
+            None,
+            None,
+            StructType::new(vec![]),
+            vec![],
+            HashMap::from_iter(vec![
+                (
+                    "delta.constraints.id".to_string(),
+                    Some("id > 0".to_string()),
+                ),
+                ("delta.blahblah".to_string(), None),
+            ]),
+        );
+
+        let constraints = state.get_constraints();
+        assert_eq!(constraints.len(), 1)
     }
 
     async fn create_test_table() -> (DeltaTable, TempDir) {

--- a/crates/deltalake-sql/src/planner.rs
+++ b/crates/deltalake-sql/src/planner.rs
@@ -48,7 +48,6 @@ impl<'a, S: ContextProvider> DeltaSqlToRel<'a, S> {
             }
             Statement::Describe(describe) => self.describe_to_plan(describe),
             Statement::Vacuum(vacuum) => self.vacuum_to_plan(vacuum),
-            _ => todo!(),
         }
     }
 
@@ -92,7 +91,6 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use datafusion_common::config::ConfigOptions;
     use datafusion_common::DataFusionError;
-
     use datafusion_expr::logical_plan::builder::LogicalTableSource;
     use datafusion_expr::{AggregateUDF, ScalarUDF, TableSource};
     use datafusion_sql::TableReference;

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -7,12 +7,12 @@ Most of the workflow is based on the `Makefile` and the `maturin` CLI tool.
 #### Setup your local environment with virtualenv
 
 ```bash
-$ make setup-venv
+make setup-venv
 ```
 
 #### Activate it
 ```bash
-$ source ./venv/bin/activate
+source ./venv/bin/activate
 ```
 
 #### Ready to develop with maturin
@@ -21,13 +21,13 @@ $ source ./venv/bin/activate
 Install delta-rs in the current virtualenv
 
 ```bash
-$ make develop
+make develop
 ```
 
 Then, list all the available tasks
 
 ```bash
-$ make help
+make help
 ```
 
 Format:

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -24,6 +24,7 @@ from typing import (
 import pyarrow
 import pyarrow.dataset as ds
 import pyarrow.fs as pa_fs
+import pyarrow_hotfix  # noqa: F401; addresses CVE-2023-47248; # type: ignore
 from pyarrow.dataset import (
     Expression,
     FileSystemDataset,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    "pyarrow>=8"
+    "pyarrow>=8",
+    "pyarrow-hotfix",    
 ]
 
 [project.optional-dependencies]
@@ -42,7 +43,7 @@ devel = [
 pyspark = [
     "pyspark",
     "delta-spark",
-    "numpy==1.22.2" # pyspark is no compatible with latest numpy
+    "numpy==1.22.2" # pyspark is not compatible with latest numpy
 ]
 
 [project.urls]
@@ -69,7 +70,6 @@ warn_unused_ignores = true
 warn_return_any = false
 implicit_reexport = true
 strict_equality = true
-
 
 [tool.black]
 include = '\.pyi?$'

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1319,7 +1319,7 @@ impl PyDeltaDataChecker {
             })
             .collect();
         Self {
-            inner: DeltaDataChecker::new(invariants),
+            inner: DeltaDataChecker::new_with_invariants(invariants),
             rt: tokio::runtime::Runtime::new().unwrap(),
         }
     }


### PR DESCRIPTION
# Description
Delta-rs always uses `item` as the list item name when writing lists. If you read data which is for example written by Spark, the item name is `element`, in the current implemantation it's not possible to write RecordBatches with a different item name. This leads for example to the problem that you cann't optimize tables which are written by Spark and contain a List column. 
In this MR I add condition which will intiate a cast if the list item name of the record batch is different to the target schema one. 
I have also tried to explain this behaviour in the tests, but unfortunately creating the test data has become complicated (Happy to get feedback)

This is my first MR in this project 

# Related Issue(s)
https://github.com/delta-io/delta-rs/blob/main/crates/deltalake-core/src/kernel/arrow/mod.rs#L58
https://github.com/delta-io/delta-rs/pull/684/files#r940790524
https://delta-users.slack.com/archives/C013LCAEB98/p1701885637615699
